### PR TITLE
deep copy libray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 _obj
 _test
 
+# IDEs
+.idea
+.vscode
+
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# AIDE-GO
+
+A go (lang) helpers library by [Hurb](https://www.hurb.com/).
+
+## Tools
+
+- [Copier](./docs/Copier.md) - A deep copy library for structs, optimized for looping and fields mapping through tags.

--- a/docs/Copier.md
+++ b/docs/Copier.md
@@ -3,7 +3,7 @@
 
 This library employs the same notation for tags as [jinzshu/copier](https://github.com/jinzhu/copier). However, this 
 solution should be more efficient because it analyzes the destination struct at initialization time, which is executed 
-at first struct copy.
+at first struct copy. If no tags was provided, the library will use the field name to perform the copy.
 
 ## Usage
 

--- a/docs/Copier.md
+++ b/docs/Copier.md
@@ -1,0 +1,67 @@
+# Copier
+## A library for creating deep copies of structs during looping.
+
+This library employs the same notation for tags as [jinzshu/copier](https://github.com/jinzhu/copier). However, this 
+solution should be more efficient because it analyzes the destination struct at initialization time, which is executed 
+at first struct copy.
+
+## Usage
+
+```go
+package main
+
+import (
+	"fmt"
+
+	aidego "github.com/hurbcom/aide-go/v4"
+)
+
+type Source struct {
+	IntValue      int
+	StringValue   string
+	FloatValue    float64
+	BoolValue     bool
+	IntPointer    *int
+	StringPointer *string
+	FloatPointer  *float64
+	BoolPointer   *bool
+}
+
+type Destination struct {
+	A bool     `copier:"BoolValue"`
+	B *float64 `copier:"FloatPointer"`
+	C string   `copier:"StringValue"`
+	D *string  `copier:"StringPointer"`
+	E *int     `copier:"IntPointer"`
+	F float64  `copier:"FloatValue"`
+	G int      `copier:"IntValue"`
+	H *bool    `copier:"BoolPointer"`
+}
+
+func main() {
+	
+	copier, err := aidego.NewCopier()
+	if err != nil {
+		panic(err)
+	}
+
+	data := GetSourceVector()
+	for _, source := range data {
+
+		var destination Destination
+        if err = copier.Copy(&source, &destination); err != nil {
+			fmt.Println(err)
+			continue
+		}
+		
+		ProccessDestination(destination)
+    }
+	
+}
+
+```
+
+# TODOs
+
+- Implement a benchmark comparing with jinzshu/copier.
+- During copying, there are more opportunities to use cached data.

--- a/v4/copier.go
+++ b/v4/copier.go
@@ -1,0 +1,165 @@
+package aidego
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type Copier struct {
+	initialized bool
+
+	sourceKinds              map[int]reflect.Kind
+	destinationKinds         map[int]reflect.Kind
+	sourceDestinationMapping map[int]int
+}
+
+func (copier *Copier) Copy(source, destination interface{}) error {
+	if !copier.initialized {
+		if err := copier.initialize(source, destination); err != nil {
+			return err
+		}
+	}
+
+	sourceValue, err := copier.getValue(source)
+	if err != nil {
+		return err
+	}
+
+	destinationValue, err := copier.getValue(destination)
+	if err != nil {
+		return err
+	}
+
+	tmpDestination := reflect.Indirect(reflect.New(destinationValue.Type()))
+
+	for k, v := range copier.sourceDestinationMapping {
+		switch {
+		case copier.destinationKinds[k] == copier.sourceKinds[v] || copier.destinationKinds[k] == reflect.Interface ||
+			copier.sourceKinds[v] == reflect.Interface:
+			tmpDestination.Field(k).Set(sourceValue.Field(v))
+		case copier.sourceKinds[v] == reflect.Ptr:
+			tmpDestination.Field(k).Set(sourceValue.Field(v).Elem())
+		case copier.destinationKinds[k] == reflect.Ptr:
+			tmpDestination.Field(k).Set(sourceValue.Field(v).Addr())
+		default:
+			return fmt.Errorf("unsupported kind combination: %s x %s", copier.sourceKinds[v].String(),
+				copier.destinationKinds[k].String())
+		}
+	}
+
+	reflect.Indirect(reflect.ValueOf(destination)).Set(tmpDestination)
+
+	return nil
+}
+
+func (copier *Copier) initialize(source, destination interface{}) error {
+	sourceType, sourceNumFields, err := copier.prepareStructs(source)
+	if err != nil {
+		return err
+	}
+
+	destinationType, destinationNumFields, err := copier.prepareStructs(destination)
+	if err != nil {
+		return err
+	}
+
+	for iDestinationField := 0; iDestinationField < destinationNumFields; iDestinationField++ {
+		destinationField := destinationType.Field(iDestinationField)
+		copier.destinationKinds[iDestinationField] = destinationField.Type.Kind()
+
+		if tag := destinationField.Tag.Get("copier"); tag != "" {
+			if tag == "-" {
+				continue
+			}
+
+			found := false
+
+			for iSourceField := 0; iSourceField < sourceNumFields; iSourceField++ {
+				sourceField := sourceType.Field(iSourceField)
+				if sourceField.Name == tag {
+					found = true
+					copier.sourceDestinationMapping[iDestinationField] = iSourceField
+					copier.sourceKinds[iSourceField] = sourceField.Type.Kind()
+
+					break
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("could not find destination field for tag %s", tag)
+			}
+		} else {
+			found := false
+			for iSourceField := 0; iSourceField < sourceNumFields; iSourceField++ {
+				sourceField := sourceType.Field(iSourceField)
+				if sourceField.Name == destinationField.Name {
+					found = true
+					copier.sourceDestinationMapping[iDestinationField] = iSourceField
+					copier.sourceKinds[iSourceField] = sourceField.Type.Kind()
+
+					break
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("could not find on destination field a corresping source field for %s",
+					destinationField.Name)
+			}
+		}
+	}
+
+	copier.initialized = true
+
+	return nil
+}
+
+func (copier *Copier) prepareStructs(data interface{}) (reflect.Type, int, error) {
+	value, err := copier.getValue(data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	numFields, err := copier.getNumFields(value)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return value.Type(), numFields, nil
+}
+
+func (copier *Copier) getValue(structInterface interface{}) (reflect.Value, error) {
+	structKind := reflect.TypeOf(structInterface).Kind()
+
+	switch {
+	case structKind == reflect.Struct:
+		return reflect.ValueOf(structInterface), nil
+	case structKind == reflect.Interface || structKind == reflect.Ptr:
+		return copier.getValue(reflect.ValueOf(structInterface).Elem().Interface())
+	default:
+		return reflect.Value{}, fmt.Errorf("source kind %v is not supported", structKind.String())
+	}
+}
+
+func (copier *Copier) getNumFields(structValue reflect.Value) (int, error) {
+	structKind := reflect.TypeOf(structValue).Kind()
+
+	switch {
+	case structKind == reflect.Struct:
+		return structValue.NumField(), nil
+
+	case structKind == reflect.Interface || structKind == reflect.Ptr:
+		return copier.getNumFields(structValue.Elem())
+
+	default:
+		return 0, fmt.Errorf("source kind %v is not supported", structKind.String())
+	}
+}
+
+func NewCopier() (*Copier, error) {
+	return &Copier{
+		initialized:              false,
+		sourceKinds:              make(map[int]reflect.Kind),
+		destinationKinds:         make(map[int]reflect.Kind),
+		sourceDestinationMapping: make(map[int]int),
+	}, nil
+}

--- a/v4/copier_test.go
+++ b/v4/copier_test.go
@@ -1,0 +1,217 @@
+package aidego
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	intValue1    = 299792458
+	floatValue1  = math.Pi
+	stringValue1 = "O ignorante afirma, o sábio duvida, o sensato reflete"
+	boolValue1   = true
+	intValue2    = 97838163
+	floatValue2  = math.E
+	stringValue2 = "A beleza das coisas existe no espírito de quem as contempla"
+	boolValue2   = false
+	intValue3    = 1602176565
+	floatValue3  = math.Ln10
+	stringValue3 = "O que não provoca minha morte faz com que eu fique mais forte"
+	boolValue3   = true
+)
+
+type TestStruct1 struct {
+	IntValue      int
+	StringValue   string
+	FloatValue    float64
+	BoolValue     bool
+	StructValue   TestStruct2
+	IntPointer    *int
+	StringPointer *string
+	FloatPointer  *float64
+	BoolPointer   *bool
+	StructPointer *TestStruct3
+}
+
+type TestStruct2 struct {
+	A bool     `copier:"BoolValue"`
+	B *float64 `copier:"FloatPointer"`
+	C string   `copier:"StringValue"`
+	D *string  `copier:"StringPointer"`
+	E *int     `copier:"IntPointer"`
+	F float64  `copier:"FloatValue"`
+	G int      `copier:"IntValue"`
+	H *bool    `copier:"BoolPointer"`
+}
+
+type TestStruct3 struct {
+	Z int      `copier:"IntValue"`
+	Y float64  `copier:"FloatValue"`
+	X string   `copier:"StringValue"`
+	W bool     `copier:"BoolValue"`
+	V *int     `copier:"IntPointer"`
+	U *float64 `copier:"FloatPointer"`
+	T *string  `copier:"-"`
+	S *bool    `copier:"BoolPointer"`
+}
+
+var (
+	intPointer1    = intValue1
+	floatPointer1  = floatValue1
+	stringPointer1 = stringValue1
+	boolPointer1   = boolValue1
+
+	intPointer2    = intValue2
+	floatPointer2  = floatValue2
+	stringPointer2 = stringValue2
+	boolPointer2   = boolValue2
+
+	testStruct1 = TestStruct1{
+		IntValue:      intValue2,
+		StringValue:   stringValue2,
+		FloatValue:    floatValue2,
+		BoolValue:     boolValue2,
+		StructValue:   testStruct2,
+		IntPointer:    &intPointer1,
+		StringPointer: &stringPointer1,
+		FloatPointer:  &floatPointer1,
+		BoolPointer:   &boolPointer1,
+		StructPointer: &testStruct3,
+	}
+
+	testStruct2 = TestStruct2{
+		A: boolValue3,
+		B: &floatPointer2,
+		C: stringValue3,
+		D: &stringPointer2,
+		E: &intPointer2,
+		F: floatValue3,
+		G: intValue3,
+		H: &boolPointer2,
+	}
+
+	testStruct3 = TestStruct3{
+		Z: intValue2,
+		Y: floatValue2,
+		X: stringValue2,
+		W: boolValue2,
+		V: &intPointer1,
+		U: &floatPointer1,
+		T: &stringPointer1,
+		S: &boolPointer1,
+	}
+)
+
+func TestCopier_Copy(t *testing.T) {
+
+	t.Run("copier.Copy: Success cases",
+		func(t *testing.T) {
+
+			var destination1 TestStruct1
+			testCopier(t, false, &testStruct1, &destination1)
+
+			assert.Equal(t, testStruct1.IntValue, destination1.IntValue)
+			assert.Equal(t, testStruct1.StringValue, destination1.StringValue)
+			assert.Equal(t, testStruct1.FloatValue, destination1.FloatValue)
+			assert.Equal(t, testStruct1.BoolValue, destination1.BoolValue)
+			assert.Equal(t, testStruct1.StructValue.A, destination1.StructValue.A)
+			assert.Equal(t, testStruct1.StructValue.B, destination1.StructValue.B)
+			assert.Equal(t, testStruct1.StructValue.C, destination1.StructValue.C)
+			assert.Equal(t, testStruct1.StructValue.D, destination1.StructValue.D)
+			assert.Equal(t, testStruct1.StructValue.E, destination1.StructValue.E)
+			assert.Equal(t, testStruct1.StructValue.F, destination1.StructValue.F)
+			assert.Equal(t, testStruct1.StructValue.G, destination1.StructValue.G)
+			assert.Equal(t, testStruct1.StructValue.H, destination1.StructValue.H)
+			assert.Equal(t, testStruct1.IntPointer, destination1.IntPointer)
+			assert.Equal(t, testStruct1.StringPointer, destination1.StringPointer)
+			assert.Equal(t, testStruct1.FloatPointer, destination1.FloatPointer)
+			assert.Equal(t, testStruct1.BoolPointer, destination1.BoolPointer)
+			assert.Equal(t, testStruct1.StructPointer, destination1.StructPointer)
+
+			var destination2 TestStruct2
+			testCopier(t, false, &testStruct1, &destination2)
+
+			assert.Equal(t, testStruct1.IntValue, destination2.G)
+			assert.Equal(t, testStruct1.StringValue, destination2.C)
+			assert.Equal(t, testStruct1.FloatValue, destination2.F)
+			assert.Equal(t, testStruct1.BoolValue, destination2.A)
+			assert.Equal(t, testStruct1.IntPointer, destination2.E)
+			assert.Equal(t, testStruct1.StringPointer, destination2.D)
+			assert.Equal(t, testStruct1.FloatPointer, destination2.B)
+			assert.Equal(t, testStruct1.BoolPointer, destination2.H)
+
+			var destination3 TestStruct3
+			testCopier(t, false, &testStruct1, &destination3)
+			assert.Equal(t, testStruct1.IntValue, destination3.Z)
+			assert.Equal(t, testStruct1.FloatValue, destination3.Y)
+			assert.Equal(t, testStruct1.StringValue, destination3.X)
+			assert.Equal(t, testStruct1.BoolValue, destination3.W)
+			assert.Equal(t, testStruct1.IntPointer, destination3.V)
+			assert.Equal(t, testStruct1.FloatPointer, destination3.U)
+			assert.Empty(t, destination3.T)
+			assert.Equal(t, testStruct1.BoolPointer, destination3.S)
+		},
+	)
+
+	t.Run("copier.Copy: it should fail when there are no match with source and destination fields",
+		func(t *testing.T) {
+
+			var destination struct {
+				A int
+				B string
+				C float64
+				D bool
+			}
+
+			testCopier(t, true, &testStruct1, &destination)
+		},
+	)
+
+	t.Run("copier.Copy: it should fail when no struct is passed as source or destination",
+		func(t *testing.T) {
+
+			intSource := intValue1
+			var intDestination int
+			testCopierParameterPassCombination(t, true, intSource, intDestination)
+
+			floatSource := floatValue1
+			var floatDestination float64
+			testCopierParameterPassCombination(t, true, floatSource, floatDestination)
+
+			stringSource := stringValue1
+			var stringDestination string
+			testCopierParameterPassCombination(t, true, stringSource, stringDestination)
+
+			var boolDestination bool
+			testCopierParameterPassCombination(t, true, boolValue1, boolDestination)
+		},
+	)
+
+}
+
+func testCopier(t *testing.T, fail bool, source, destination interface{}) {
+	t.Helper()
+
+	copier, err := NewCopier()
+	assert.NoError(t, err)
+
+	err = copier.Copy(source, destination)
+	if fail {
+		assert.Error(t, err)
+	} else {
+		assert.NoError(t, err)
+	}
+
+	return
+}
+
+func testCopierParameterPassCombination(t *testing.T, fail bool, source, destination interface{}) {
+	t.Helper()
+
+	testCopier(t, fail, &source, &destination)
+	testCopier(t, fail, source, destination)
+	testCopier(t, fail, source, &destination)
+	testCopier(t, fail, &source, destination)
+}


### PR DESCRIPTION
## Tarefa / *user history*

- Implementação de uma lib para realizar deep copies realizando de-para de campo a qual será utilizada pelo struct-reader, que realiza a leitura de arquivo parquet para o filtro de Buscas do HPA para o Janus.

## O quê esse PR faz?

- Implementa uma biblioteca para realizar deep copies dentro de loopings;
- Utiliza anotações para realizar de-para de campos;
- Baseada na [jinzhu/copier](https://github.com/jinzhu/copier), porém com cache para possibilitar sua utilização em loopings.

### - Antes

- Nova implementação

### - Depois

- Vide documentação na pasta docs

### - Como testar?

- `cd v4`
- `go test .`

### - TODOs
- [ ] Testes
- [ ] Documentação
- [ ] Débito técnico

### - PRs relacionados

branch | PR
------ | ------
[feature/v4](https://github.com/hurbcom/aide-go/tree/feature/v4)

## Criou o RC a partir da master?
- [ ] Sim
- [ X ] Não

## Precisa de migration?
- [ ] Sim
- [ X ] Não

@mencione pessoas do time envolvidas com o PR, se necessário.

E agradeça os coleguinhas!

## Risks

