### PR TITLE
fix aide go deep copier funcion on zero value pointers

### DIFF
--- a/v4/copier.go
+++ b/v4/copier.go
@@ -38,7 +38,9 @@ func (copier *Copier) Copy(source, destination interface{}) error {
 			copier.sourceKinds[v] == reflect.Interface:
 			tmpDestination.Field(k).Set(sourceValue.Field(v))
 		case copier.sourceKinds[v] == reflect.Ptr:
-			tmpDestination.Field(k).Set(sourceValue.Field(v).Elem())
+			if !sourceValue.Field(v).IsZero() {
+				tmpDestination.Field(k).Set(sourceValue.Field(v).Elem())
+			}
 		case copier.destinationKinds[k] == reflect.Ptr:
 			tmpDestination.Field(k).Set(sourceValue.Field(v).Addr())
 		default:


### PR DESCRIPTION
## Tarefa / Ajuste no DBGenerator para suportar a geração de base do SKUDictionary

Veja [MS-554](https://hurbcom.atlassian.net/browse/MS-554)


## O quê esse PR faz?

- Corrige um bug no aide-go/v4/Copier que ao receber ponteiros com valores zero causavam panic durante a leitura de arquivos parquet.

### - Antes

- Panic quando recebíamos ponteiros zerados

### - Depois

- O campo destino é ajustado para nil (ignorado)

### - Como testar?

- make test

### - TODOs
- [ ] Testes
- [ ] Documentação
- [ ] Débito técnico

### - PRs relacionados

branch | PR
------ | ------
v4

## Criou o RC a partir da master?
- [ ] Sim
- [ x ] Não

## Precisa de migration?
- [ ] Sim
- [ x ] Não
