### PR TITLE
Feature/copier destination field cast and slices/arrays handling

### DIFF
--- a/v4/copier.go
+++ b/v4/copier.go
@@ -34,6 +34,18 @@ func (copier *Copier) Copy(source, destination interface{}) error {
 
 	for k, v := range copier.sourceDestinationMapping {
 		switch {
+		case copier.sourceKinds[v] == reflect.Slice || copier.sourceKinds[v] == reflect.Array:
+			sourceSlice := sourceValue.Field(v)
+			sliceLength := sourceSlice.Len()
+			destinationSlice := reflect.MakeSlice(destinationValue.Field(k).Type(), sliceLength, sliceLength)
+			sliceElemType := reflect.TypeOf(destinationSlice.Interface()).Elem()
+
+			for l := 0; l < sliceLength; l++ {
+				destinationSlice.Index(l).Set(sourceSlice.Index(l).Convert(sliceElemType))
+			}
+
+			tmpDestination.Field(k).Set(destinationSlice)
+
 		case copier.destinationKinds[k] == copier.sourceKinds[v] || copier.destinationKinds[k] == reflect.Interface ||
 			copier.sourceKinds[v] == reflect.Interface:
 			destinationType := tmpDestination.Field(k).Type()

--- a/v4/copier.go
+++ b/v4/copier.go
@@ -36,13 +36,16 @@ func (copier *Copier) Copy(source, destination interface{}) error {
 		switch {
 		case copier.destinationKinds[k] == copier.sourceKinds[v] || copier.destinationKinds[k] == reflect.Interface ||
 			copier.sourceKinds[v] == reflect.Interface:
-			tmpDestination.Field(k).Set(sourceValue.Field(v))
+			destinationType := tmpDestination.Field(k).Type()
+			tmpDestination.Field(k).Set(sourceValue.Field(v).Convert(destinationType))
 		case copier.sourceKinds[v] == reflect.Ptr:
 			if !sourceValue.Field(v).IsZero() {
-				tmpDestination.Field(k).Set(sourceValue.Field(v).Elem())
+				destinationType := tmpDestination.Field(k).Type()
+				tmpDestination.Field(k).Set(sourceValue.Field(v).Elem().Convert(destinationType))
 			}
 		case copier.destinationKinds[k] == reflect.Ptr:
-			tmpDestination.Field(k).Set(sourceValue.Field(v).Addr())
+			destinationType := tmpDestination.Field(k).Type()
+			tmpDestination.Field(k).Set(sourceValue.Field(v).Addr().Convert(destinationType))
 		default:
 			return fmt.Errorf("unsupported kind combination: %s x %s", copier.sourceKinds[v].String(),
 				copier.destinationKinds[k].String())

--- a/v4/copier_test.go
+++ b/v4/copier_test.go
@@ -56,6 +56,57 @@ type TestStruct3 struct {
 	T *string  `copier:"-"`
 	S *bool    `copier:"BoolPointer"`
 }
+type SliceTestStructSource struct {
+	IntSlice    []int
+	StringSlice []string
+	FloatSlice  []float64
+	BoolSlice   []bool
+	StructSlice []TestStruct2
+
+	IntSlicePointer    *[]int
+	StringSlicePointer *[]string
+	FloatSlicePointer  *[]float64
+	BoolSlicePointer   *[]bool
+	StructSlicePointer *[]TestStruct3
+
+	IntPointerSlice    []*int
+	StringPointerSlice []*string
+	FloatPointerSlice  []*float64
+	BoolPointerSlice   []*bool
+	StructPointerSlice []*TestStruct2
+
+	IntSlicePointerPointer    *[]*int
+	StringPointerSlicePointer *[]*string
+	FloatPointerSlicePointer  *[]*float64
+	BoolPointerSlicePointer   *[]*bool
+	StructPointerSlicePointer *[]*TestStruct3
+}
+
+type SliceTestStructDestination struct {
+	A []int         `copier:"IntSlice"`
+	B []string      `copier:"StringSlice"`
+	C []float64     `copier:"FloatSlice"`
+	D []bool        `copier:"BoolSlice"`
+	E []TestStruct2 `copier:"StructSlice"`
+
+	F *[]int         `copier:"IntSlicePointer"`
+	G *[]string      `copier:"StringSlicePointer"`
+	H *[]float64     `copier:"FloatSlicePointer"`
+	I *[]bool        `copier:"BoolSlicePointer"`
+	J *[]TestStruct3 `copier:"StructSlicePointer"`
+
+	K []*int         `copier:"IntPointerSlice"`
+	L []*string      `copier:"StringPointerSlice"`
+	M []*float64     `copier:"FloatPointerSlice"`
+	N []*bool        `copier:"BoolPointerSlice"`
+	O []*TestStruct2 `copier:"StructPointerSlice"`
+
+	P *[]*int         `copier:"IntSlicePointerPointer"`
+	Q *[]*string      `copier:"StringPointerSlicePointer"`
+	R *[]*float64     `copier:"FloatPointerSlicePointer"`
+	S *[]*bool        `copier:"BoolPointerSlicePointer"`
+	T *[]*TestStruct3 `copier:"StructPointerSlicePointer"`
+}
 
 var (
 	intPointer1    = intValue1
@@ -102,11 +153,37 @@ var (
 		T: &stringPointer1,
 		S: &boolPointer1,
 	}
+
+	testSliceSource = SliceTestStructSource{
+		IntSlice:    []int{intValue1, intValue2, intValue3},
+		StringSlice: []string{stringValue1, stringValue2, stringValue3},
+		FloatSlice:  []float64{floatValue1, floatValue2, floatValue3},
+		BoolSlice:   []bool{boolValue1, boolValue2},
+		StructSlice: []TestStruct2{testStruct2},
+
+		IntSlicePointer:    &[]int{intValue1, intValue2, intValue3},
+		StringSlicePointer: &[]string{stringValue1, stringValue2, stringValue3},
+		FloatSlicePointer:  &[]float64{floatValue1, floatValue2, floatValue3},
+		BoolSlicePointer:   &[]bool{boolValue1, boolValue2},
+		StructSlicePointer: &[]TestStruct3{testStruct3},
+
+		IntPointerSlice:    []*int{&intPointer1, &intPointer2},
+		StringPointerSlice: []*string{&stringPointer1, &stringPointer2},
+		FloatPointerSlice:  []*float64{&floatPointer1, &floatPointer2},
+		BoolPointerSlice:   []*bool{&boolPointer1, &boolPointer2},
+		StructPointerSlice: []*TestStruct2{&testStruct2},
+
+		IntSlicePointerPointer:    &[]*int{&intPointer1, &intPointer2},
+		StringPointerSlicePointer: &[]*string{&stringPointer1, &stringPointer2},
+		FloatPointerSlicePointer:  &[]*float64{&floatPointer1, &floatPointer2},
+		BoolPointerSlicePointer:   &[]*bool{&boolPointer1, &boolPointer2},
+		StructPointerSlicePointer: &[]*TestStruct3{&testStruct3},
+	}
 )
 
 func TestCopier_Copy(t *testing.T) {
 
-	t.Run("copier.Copy: Success cases",
+	t.Run("copier.Copy: success cases",
 		func(t *testing.T) {
 
 			var destination1 TestStruct1
@@ -152,6 +229,35 @@ func TestCopier_Copy(t *testing.T) {
 			assert.Equal(t, testStruct1.FloatPointer, destination3.U)
 			assert.Empty(t, destination3.T)
 			assert.Equal(t, testStruct1.BoolPointer, destination3.S)
+		},
+	)
+
+	t.Run("copier.Copy: arrays and slices success cases",
+		func(t *testing.T) {
+
+			var destination1 SliceTestStructDestination
+			testCopier(t, false, &testSliceSource, &destination1)
+
+			assert.Equal(t, testSliceSource.IntSlice, destination1.A)
+			assert.Equal(t, testSliceSource.StringSlice, destination1.B)
+			assert.Equal(t, testSliceSource.FloatSlice, destination1.C)
+			assert.Equal(t, testSliceSource.BoolSlice, destination1.D)
+			assert.Equal(t, testSliceSource.StructSlice, destination1.E)
+			assert.Equal(t, testSliceSource.IntSlicePointer, destination1.F)
+			assert.Equal(t, testSliceSource.StringSlicePointer, destination1.G)
+			assert.Equal(t, testSliceSource.FloatSlicePointer, destination1.H)
+			assert.Equal(t, testSliceSource.BoolSlicePointer, destination1.I)
+			assert.Equal(t, testSliceSource.StructSlicePointer, destination1.J)
+			assert.Equal(t, testSliceSource.IntPointerSlice, destination1.K)
+			assert.Equal(t, testSliceSource.StringPointerSlice, destination1.L)
+			assert.Equal(t, testSliceSource.FloatPointerSlice, destination1.M)
+			assert.Equal(t, testSliceSource.BoolPointerSlice, destination1.N)
+			assert.Equal(t, testSliceSource.StructPointerSlice, destination1.O)
+			assert.Equal(t, testSliceSource.IntSlicePointerPointer, destination1.P)
+			assert.Equal(t, testSliceSource.StringPointerSlicePointer, destination1.Q)
+			assert.Equal(t, testSliceSource.FloatPointerSlicePointer, destination1.R)
+			assert.Equal(t, testSliceSource.BoolPointerSlicePointer, destination1.S)
+			assert.Equal(t, testSliceSource.StructPointerSlicePointer, destination1.T)
 		},
 	)
 

--- a/v4/copier_test.go
+++ b/v4/copier_test.go
@@ -56,6 +56,7 @@ type TestStruct3 struct {
 	T *string  `copier:"-"`
 	S *bool    `copier:"BoolPointer"`
 }
+
 type SliceTestStructSource struct {
 	IntSlice    []int
 	StringSlice []string


### PR DESCRIPTION
## Feature/copier destination field cast and slices/arrays handling

Veja [MS-588](https://hurbcom.atlassian.net/browse/MS-588)

## O quê esse PR faz?

- Adiciona o tratamento de Slices e Arrays na biblioteca de deep copy  da AIDE-GO
- Adiciona a realização de casting, quando possível na biblioteca de casting da AIDE-GO

### - Antes

- Funcionalidades não suportadas

### - Depois

- É possível realizar a cópia de campos do tipo Slice e Array 
- É possível realizar a cópia de campos cujo o cast é viável

### - Como testar?

- `make test`

### - TODOs
- [ ] Testes
- [ ] Documentação
- [ ] Débito técnico

## Criou o RC a partir da master?
- [ ] Sim
- [X] Não

## Precisa de migration?
- [ ] Sim
- [X] Não
